### PR TITLE
Link the group site at stai-lab.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
         </div>
         <div class="col-sm-8 name-column text-right" style="min-width: 266px;">
           <p style="text-align:right">
-            <a href="https://s-t-a-i.github.io/"><img src="pictures/stai_logo.png" alt="Scalable Trustworthy AI logo" class="institute-logo"></a>
+            <a href="https://stai-lab.org/"><img src="pictures/stai_logo.png" alt="Scalable Trustworthy AI logo" class="institute-logo"></a>
               &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             <a href="https://gsai.kaist.ac.kr/"><img src="pictures/logo_kaist.png" alt="KAIST AI logo" class="institute-logo"></a>
           </p>
@@ -107,7 +107,7 @@
             I believe trustworthiness is the last barrier to the AI productivity revolution. I research <emph>Scalable Trustworthy AI</emph>: making AI systems reliable, explainable, and aligned with human intent at scale.
           </p>
           <p>
-            I lead the <a href="https://s-t-a-i.github.io/">Scalable Trustworthy AI (STAI)</a> group since 2022. I moved the group from <a href="https://tuebingen.ai/">University of Tübingen</a> to KAIST in February 2026.
+            I lead the <a href="https://stai-lab.org/">Scalable Trustworthy AI (STAI)</a> group since 2022. I moved the group from <a href="https://tuebingen.ai/">University of Tübingen</a> to KAIST in February 2026.
             I was a research scientist at <a href="https://github.com/naver-ai">NAVER AI Lab</a> for 3.5 years.
             I received my PhD in computer vision and machine learning at <a href="https://www.mpi-inf.mpg.de/departments/computer-vision-and-machine-learning">Max-Planck Institute for Informatics</a> in 2018,
             under the supervision of <a href="https://www.mpi-inf.mpg.de/departments/computer-vision-and-machine-learning/people/bernt-schiele">Bernt Schiele</a> and <a href="https://cispa.saarland/group/fritz/">Mario Fritz</a>,
@@ -121,7 +121,7 @@
           </p>
 
           <p>
-            If you wish to apply for a position at STAI, please email <a href="mailto:stai.there@gmail.com">stai.there@gmail.com</a> (not my personal address). See the <a href="https://s-t-a-i.github.io/#openings">openings</a> page for more details.
+            If you wish to apply for a position at STAI, please email <a href="mailto:stai.there@gmail.com">stai.there@gmail.com</a> (not my personal address). See the <a href="https://stai-lab.org/opening/">openings</a> page for more details.
           </p>
 
           <p style="text-align:center">


### PR DESCRIPTION
Three links on the homepage. The old host redirects, so nothing was broken.

The openings link also gains a working target - the group site is multi-page now, so `#openings` pointed at nothing. It goes to `https://stai-lab.org/opening/` (verified 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)