### PR TITLE
Point STAI applications at the openings page form

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           </p>
 
           <p>
-            If you wish to apply for a position at STAI, please email <a href="mailto:stai.there@gmail.com">stai.there@gmail.com</a> (not my personal address). See the <a href="https://s-t-a-i.github.io/#openings">openings</a> page for more details.
+            If you wish to apply for a position at STAI, please apply through the form linked on the <a href="https://s-t-a-i.github.io/#openings">openings</a> page. We no longer take applications by email.
           </p>
 
           <p style="text-align:center">

--- a/index.html
+++ b/index.html
@@ -128,7 +128,8 @@
             <a href="https://scholar.google.com/citations?user=kmXOOdsAAAAJ&hl=en">Google Scholar</a> &nbsp;/&nbsp;
             <a href="https://www.linkedin.com/in/seong-joon-oh-32113479/">LinkedIn</a> &nbsp;/&nbsp;
             <a href="https://twitter.com/coallaoh/">Twitter</a> &nbsp;/&nbsp;
-            <a href="https://github.com/coallaoh/">Github</a>
+            <a href="https://github.com/coallaoh/">Github</a> &nbsp;/&nbsp;
+            <a href="mailto:coallaoh@kaist.ac.kr">Email</a>
           </p>
 
         </div>


### PR DESCRIPTION
We no longer take applications by email. The line on the front page now sends applicants to the form linked from the openings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)