### PR TITLE
Point the openings link at stai-lab.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           </p>
 
           <p>
-            If you wish to apply for a position at STAI, please apply through the form linked on the <a href="https://s-t-a-i.github.io/#openings">openings</a> page. We no longer take applications by email.
+            If you wish to apply for a position at STAI, please apply through the form linked on the <a href="https://stai-lab.org/opening/">openings</a> page. We no longer take applications by email.
           </p>
 
           <p style="text-align:center">


### PR DESCRIPTION
The old link went to the s-t-a-i.github.io homepage anchor. The group site now lives at stai-lab.org and has a dedicated openings section page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)