### PR TITLE
Add the 2026 KAIST students to the supervision records

### DIFF
--- a/data/authors.js
+++ b/data/authors.js
@@ -890,7 +890,7 @@ const authorsData = {
       "isMe": false,
       "startYear": 2026,
       "endYear": null,
-      "type": "intern"
+      "type": "phd"
     },
     {
       "id": "luca_fuger",
@@ -1025,6 +1025,96 @@ const authorsData = {
       "type": "phd"
     },
     {
+      "id": "hyeonbin_hwang",
+      "name": "Hyeonbin Hwang",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "phd"
+    },
+    {
+      "id": "ji_hwan_lim",
+      "name": "Ji Hwan Lim",
+      "url": "",
+      "isMe": false,
+      "startYear": 2025,
+      "endYear": null,
+      "type": "phd"
+    },
+    {
+      "id": "yerang_kim",
+      "name": "Yerang Kim",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "master"
+    },
+    {
+      "id": "dohyun_kim",
+      "name": "Dohyun Kim",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "master"
+    },
+    {
+      "id": "viacheslav_sinii",
+      "name": "Viacheslav Sinii",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "master"
+    },
+    {
+      "id": "seungwon_park",
+      "name": "Seungwon Park",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "intern"
+    },
+    {
+      "id": "sunghyun_park",
+      "name": "Sunghyun Park",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "intern"
+    },
+    {
+      "id": "junho_jeong",
+      "name": "Junho Jeong",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "intern"
+    },
+    {
+      "id": "daeun_park",
+      "name": "Daeun Park",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "intern"
+    },
+    {
+      "id": "sam_lee",
+      "name": "Sam Lee",
+      "url": "",
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "intern"
+    },
+    {
       "id": "yunjae_won",
       "name": "Yunjae Won",
       "url": "https://yunjae-won.github.io/",
@@ -1055,7 +1145,10 @@ const authorsData = {
       "id": "sangwoo_park",
       "name": "Sangwoo Park",
       "url": "https://www.linkedin.com/in/swgger",
-      "isMe": false
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "phd"
     },
     {
       "id": "woongyeong_yeo",
@@ -1103,7 +1196,10 @@ const authorsData = {
       "id": "shuman_peng",
       "name": "Shuman Peng",
       "url": "https://sites.google.com/view/shumanp",
-      "isMe": false
+      "isMe": false,
+      "startYear": 2026,
+      "endYear": null,
+      "type": "phd"
     },
     {
       "id": "martin_ester",


### PR DESCRIPTION
Adds the students who joined at KAIST in 2026 to `data/authors.js`, taken from the lab roster.

- New PhD students: Hyeonbin Hwang, Ji Hwan Lim (integrated MS-PhD, from 2025).
- Shuman Peng and Sangwoo Park already had author entries; they now carry PhD supervision records.
- Yejin Kim moves from intern to PhD student.
- New master students: Yerang Kim, Dohyun Kim, Viacheslav Sinii.
- New research interns: Seungwon Park, Sunghyun Park, Junho Jeong, Daeun Park, Sam Lee.

This is the source the CV supervision list is generated from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)