### PR TITLE
Link NowDo from the front page and the updates

### DIFF
--- a/data/updates.js
+++ b/data/updates.js
@@ -5,7 +5,7 @@ const updatesData = [
   {
     date: '2026-09-04',
     id: 'update-2026-09-04-nowdo-launch',
-    html: "4 September 2026. <a href=\"https://nowdo.ai\">NowDo</a> is out on web and iPhone. An assistant that plans your day, and asks before it moves anything."
+    html: "4 September 2026. <a href=\"https://nowdo.ai\">NowDo</a> is out on web and iPhone. AI plans your day, and your feedback builds the app."
   },
   {
     date: '2026-08-21',

--- a/data/updates.js
+++ b/data/updates.js
@@ -3,6 +3,11 @@
 // The FE will render the latest 5 items.
 const updatesData = [
   {
+    date: '2026-09-04',
+    id: 'update-2026-09-04-nowdo-launch',
+    html: "4 September 2026. <a href=\"https://nowdo.ai\">NowDo</a> is out on web and iPhone. An assistant that plans your day, and asks before it moves anything."
+  },
+  {
     date: '2026-08-21',
     id: 'update-2026-08-21-emnlp26-acceptance',
     html: "21 August 2026. 1 paper accepted @ EMNLP'26 Findings: <a href=\"#philipp2026nonattrib\">LLM Generation Novelty Through the Lens of Semantic Similarity</a>."

--- a/index.html
+++ b/index.html
@@ -121,6 +121,11 @@
           </p>
 
           <p>
+            I build <a href="https://nowdo.ai">NowDo</a>, an assistant that plans your day and asks before it moves anything.
+            It is where the trustworthiness questions meet real users.
+          </p>
+
+          <p>
             If you wish to apply for a position at STAI, please apply through the form linked on the <a href="https://stai-lab.org/opening/">openings</a> page. We no longer take applications by email.
           </p>
 

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           </p>
 
           <p>
-            I build <a href="https://nowdo.ai">NowDo</a>, an assistant that plans your day and asks before it moves anything.
+            I build <a href="https://nowdo.ai">NowDo</a>. AI plans your day, and your feedback builds the app.
             It is where the trustworthiness questions meet real users.
           </p>
 


### PR DESCRIPTION
Two additions, no other changes.

- A short paragraph after the principles line, naming NowDo and what it does.
- An updates entry dated 4 September 2026, so the launch shows in the Updates list.

The updates file still parses and still sorts newest first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)